### PR TITLE
Record "2" moves (eg. L2) as one Turn

### DIFF
--- a/modules/constants.ts
+++ b/modules/constants.ts
@@ -8,6 +8,7 @@ export const COLORS: number[] = [WHITE, GREEN, RED, YELLOW, BLUE, ORANGE]
 
 export const CLOCKWISE = 1
 export const COUNTER_CLOCKWISE = -1
+export const DOUBLE = 2
 
 export const FACE_COUNT = 6
 export const PIECES_PER_FACE = 9

--- a/modules/cube-objects.ts
+++ b/modules/cube-objects.ts
@@ -1,4 +1,4 @@
-import {COLORS, CLOCKWISE, COUNTER_CLOCKWISE, CORNER_PIECE, EDGE_PIECE, CENTER_PIECE} from './constants'
+import {COLORS, CLOCKWISE, COUNTER_CLOCKWISE, CORNER_PIECE, EDGE_PIECE, CENTER_PIECE, DOUBLE} from './constants'
 
 import { getOppositeColor, incrementColor, isOddColor, getLetterForColor, getTerminalColorFunction } from './color-functions'
 
@@ -403,7 +403,7 @@ export class Cube {
     }
 
     getTurnHistoryAsString (): string {
-        return this.getTurnHistory().map(turn => [`U`, `F`, `R`, `D`, `B`, `L`][turn.getFace().getId()] + (turn.getDirection() === COUNTER_CLOCKWISE ? `'` : ``)).join(` `)
+        return this.getTurnHistory().map(turn => [`U`, `F`, `R`, `D`, `B`, `L`][turn.getFace().getId()] + (turn.getDirection() === DOUBLE ? `2` : (turn.getDirection() === COUNTER_CLOCKWISE ? `'` : ``))).join(` `)
     }
 
     simplifyTurnHistory (silent = true): void {
@@ -436,8 +436,7 @@ export class Cube {
             if (finalDirection === 0) {
                 // Do nothing
             } else if (finalDirection === 2 || finalDirection === -2) {
-                newTurnHistory.push(new Turn(turn.getFace(), finalDirection / 2))
-                newTurnHistory.push(new Turn(turn.getFace(), finalDirection / 2))
+                newTurnHistory.push(new Turn(turn.getFace(), Math.abs(finalDirection)))
             } else {
                 newTurnHistory.push(new Turn(turn.getFace(), finalDirection))
             }


### PR DESCRIPTION
Need to decide if I should do this.

Cube notation generally counts L2 as one 'move'.

However, it still needs to move the face the same amount.

On the other hand though, moving one face 180º is quicker for the robot than moving two different faces 90º unless they are opposite. So in terms of prioritising how quick it is, it would sort of be in between one move and two moves. I actually think there should be a method which converts the turn history into a speed rating for the robot which would rate 180º better than 2x 90º but not as good as 1x 90º or 2x 90º where the faces are opposite. This score can then be used to get the most efficient solve for the robot.